### PR TITLE
Fix incorrect usage of `use strict` on `assign` module

### DIFF
--- a/src/assign.js
+++ b/src/assign.js
@@ -1,4 +1,4 @@
-'set strict'
+'use strict'
 const copy = require('./copy')
 const curry = require('./curry')
 const str = require('./str')


### PR DESCRIPTION
<!--

Thank you for taking the time to contribute to Arare!

For more info on how to contribute to the project, please read the [contributing guidelines](https://github.com/klaussinani/arare/blob/master/contributing.md).

If your Pull Request fixes any open issues, reference the corresponding issues, e.g: `Fixes #321`.

Including test results, screenshots/gifs, if possible, alongside new features and bug fixes is something that we strongly encourage.

Thank you so much for all of the your time and effort!

-->
